### PR TITLE
[ new ] drop

### DIFF
--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -3,7 +3,6 @@ module Data.Array
 import public Data.Array.Core
 import public Data.Array.Index
 import public Data.Array.Indexed
-import public Syntax.T1
 
 %default total
 

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -103,10 +103,10 @@ take k (A size arr) with (k <= size) proof eq
 partial export %inline
 drop : Nat -> Array a -> Array a
 drop k (A size arr) =
-  case k <= size of
-    False =>
-      empty
+  case k >= size of
     True  =>
+      empty
+    False =>
       let drop' = unsafeCreate size
                                (go k 0 size (A size arr))
         in take (minus size k) drop'

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -133,13 +133,13 @@ drop k (A size arr) =
     go :  (i : Nat)
        -> (m : Nat)
        -> List a
-       -> {auto 0 v  : LTE i m}
-       -> {auto 0 v' : LTE 1 m}
+       -> {auto 0 v   : LTE i m}
+       -> {auto 0 v'  : LTE 1 m}
        -> FromMArray m a (Array a)
     go i m Nil       r     = T1.do
       res <- freeze r
       pure $ A m res
-    go 0     m (x :: xs) r =
+    go 0 m (x :: xs) r =
       case tryNatToFin 0 of
         Nothing =>
           go 1 m xs r
@@ -149,10 +149,10 @@ drop k (A size arr) =
     go (S i) m (x :: xs) r =
       case tryNatToFin i of
         Nothing =>
-          go i m xs r
+          go (S i) m xs r
         Just i' => T1.do
           set r i' x
-          go i m xs r
+          go (S i) m xs r
 
 export %inline
 filter : (a -> Bool) -> Array a -> Array a

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -3,9 +3,6 @@ module Data.Array
 import public Data.Array.Core
 import public Data.Array.Index
 import public Data.Array.Indexed
-import public Data.Array.Mutable
-import public Data.Fin
-import public Data.Vect
 import public Syntax.T1
 
 %default total

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -103,9 +103,13 @@ take k (A size arr) with (k <= size) proof eq
 partial export %inline
 drop : Nat -> Array a -> Array a
 drop k (A size arr) =
-  let drop' = unsafeCreate size
-                           (go k 0 size (A size arr))
-    in take (minus size k) drop'
+  case k <= size of
+    False =>
+      empty
+    True  =>
+      let drop' = unsafeCreate size
+                               (go k 0 size (A size arr))
+        in take (minus size k) drop'
   where
       go :  (l : Nat)
          -> (z : Nat)

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -116,7 +116,7 @@ drop k (A size arr) =
          -> Array a
          -> FromMArray n a (Array a)
       go l z n (A size arr) r with (tryNatToFin {k=size} l) 
-         go l z n (A size arr) r | l' with (tryNatToFin {k=n} z) | (l <= n)
+         go l z n (A size arr) r | l' with (tryNatToFin {k=n} z) | (z <= n)
           go l z n (A size arr) r | Just k' | Just z' | True  = T1.do
                                                                   set r z' (at arr k')
                                                                   go (S k) (S z) n (A size arr) r

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -117,42 +117,65 @@ take k (A size arr) with (k <= size) proof eq
   _ | True  = A k $ take k arr @{lteOpReflectsLTE _ _ eq}
   _ | False = A size arr
 
+{-
 export %inline
 drop : Nat -> Array a -> Array a
 drop k (A size arr) =
   let m = minus size k
       i = 0
-      l = map Builtin.snd                       $
-           Prelude.toList                       $ 
-             map (\(i, x) => (minus i k, x))    $
-               map (\(i, x) => (finToNat i, x)) $
-                 drop k                         $
-                   toVectWithIndex arr
+      l = map Builtin.snd                        $
+            Prelude.toList                       $
+              map (\(i, x) => (minus i k, x))    $
+                map (\(i, x) => (finToNat i, x)) $
+                  drop {m=m} k                   $
+                    toVectWithIndex arr
     in unsafeCreate m (go i m l)
   where
-    go :  (i : Nat)
-       -> (m : Nat)
-       -> List a
-       -> {auto 0 v   : LTE i m}
-       -> {auto 0 v'  : LTE 1 m}
-       -> FromMArray m a (Array a)
-    go i     m Nil       r = T1.do
-      res <- freeze r
-      pure $ A m res
-    go 0     m (x :: xs) r =
-      case tryNatToFin 0 of
-        Nothing =>
-          go (S 0) m xs r
-        Just i' => T1.do
-          set r i' x
-          go (S 0) m xs r
-    go (S i) m (x :: xs) r =
-      case tryNatToFin i of
-        Nothing =>
-          go (S i) m xs r
-        Just i' => T1.do
-          set r i' x
-          go (S i) m xs r
+      go :  (i : Nat)
+         -> (m : Nat)
+         -> List a
+         -> {auto 0 _ : LTE i m}
+         -> {auto 0 _ : LTE 1 m}
+         -> FromMArray m a (Array a)
+      go i     m Nil       r = T1.do
+        res <- freeze r
+        pure $ A m res
+      go 0     m (x :: xs) r =
+        case tryNatToFin 0 of
+          Nothing =>
+            go (S 0) m xs r
+          Just i' => T1.do
+            set r i' x
+            go (S 0) m xs r
+      go (S i) m (x :: xs) r =
+        case tryNatToFin i of
+          Nothing =>
+            go (S i) m xs r
+          Just i' => T1.do
+            set r i' x
+            go (S i) m xs r
+-}
+partial export %inline
+drop : Nat -> Array a -> Array a
+drop k (A size arr) =
+  let drop' = unsafeCreate size
+                           (go k 0 size (A size arr))
+    in take (minus size k) drop'
+  where
+      go :  (k : Nat)
+         -> (z : Nat)
+         -> (n : Nat)
+         -> Array a
+         -> FromMArray n a (Array a)
+      go k z n (A size arr) r with (tryNatToFin k) | (tryNatToFin z) | (k <= n)
+         _ | Just k' | Just z' | True  = T1.do
+                                           set r z' (at arr k')
+                                           go (S k) (S z) n (A size arr) r
+         _ | _       | Nothing | True  = go (S k) (S z) n (A size arr) r
+         _ | Nothing | _       | True  = go (S k) (S z) n (A size arr) r
+         _ | _       | _       | False = T1.do
+                                           res <- freeze r
+                                           pure $ A n res
 
 export %inline
 filter : (a -> Bool) -> Array a -> Array a

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -116,12 +116,12 @@ drop k (A size arr) =
          -> Array a
          -> FromMArray n a (Array a)
       go l z n (A size arr) r with (tryNatToFin {k=size} l) 
-         go l z n (A size arr) r | l' with (tryNatToFin {k=n} z) | (z <= n)
-          go l z n (A size arr) r | Just k' | Just z' | True  = T1.do
-                                                                  set r z' (at arr k')
-                                                                  go (S k) (S z) n (A size arr) r
-          go l z n (A size arr) r | _       | Nothing | True  = go (S k) (S z) n (A size arr) r
-          go l z n (A size arr) r | Nothing | _       | True  = go (S k) (S z) n (A size arr) r
+        go l z n (A size arr) r | l' with (tryNatToFin {k=n} z) | (z <= n)
+          go l z n (A size arr) r | Just l'' | Just z' | True  = T1.do
+                                                                   set r z' (at arr l'')
+                                                                   go (S l) (S z) n (A size arr) r
+          go l z n (A size arr) r | _       | Nothing | True  = go (S l) (S z) n (A size arr) r
+          go l z n (A size arr) r | Nothing | _       | True  = go (S l) (S z) n (A size arr) r
           go l z n (A size arr) r | _       | _       | False = T1.do
                                                                   res <- freeze r
                                                                   pure $ A n res

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -142,10 +142,10 @@ drop k (A size arr) =
     go 0     m (x :: xs) r =
       case tryNatToFin 0 of
         Nothing =>
-          go 1 m xs r
+          go (S 0) m xs r
         Just i' => T1.do
           set r i' x
-          go 1 m xs r
+          go (S 0) m xs r
     go (S i) m (x :: xs) r =
       case tryNatToFin i of
         Nothing =>

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -136,10 +136,10 @@ drop k (A size arr) =
        -> {auto 0 v   : LTE i m}
        -> {auto 0 v'  : LTE 1 m}
        -> FromMArray m a (Array a)
-    go i m Nil       r     = T1.do
+    go i     m Nil       r = T1.do
       res <- freeze r
       pure $ A m res
-    go 0 m (x :: xs) r =
+    go 0     m (x :: xs) r =
       case tryNatToFin 0 of
         Nothing =>
           go 1 m xs r

--- a/src/Data/Array.idr
+++ b/src/Data/Array.idr
@@ -100,32 +100,9 @@ take k (A size arr) with (k <= size) proof eq
   _ | True  = A k $ take k arr @{lteOpReflectsLTE _ _ eq}
   _ | False = A size arr
 
-partial export %inline
+export %inline
 drop : Nat -> Array a -> Array a
-drop k (A size arr) =
-  case k >= size of
-    True  =>
-      empty
-    False =>
-      let drop' = unsafeCreate size
-                               (go k 0 size (A size arr))
-        in take (minus size k) drop'
-  where
-      go :  (l : Nat)
-         -> (z : Nat)
-         -> (n : Nat)
-         -> Array a
-         -> FromMArray n a (Array a)
-      go l z n (A size arr) r with (tryNatToFin {k=size} l) 
-        go l z n (A size arr) r | l' with (tryNatToFin {k=n} z) | (z <= n)
-          go l z n (A size arr) r | Just l'' | Just z' | True  = T1.do
-                                                                   set r z' (at arr l'')
-                                                                   go (S l) (S z) n (A size arr) r
-          go l z n (A size arr) r | _       | Nothing | True  = go (S l) (S z) n (A size arr) r
-          go l z n (A size arr) r | Nothing | _       | True  = go (S l) (S z) n (A size arr) r
-          go l z n (A size arr) r | _       | _       | False = T1.do
-                                                                  res <- freeze r
-                                                                  pure $ A n res
+drop n (A size arr) = A (size `minus` n) (drop n arr)
 
 export %inline
 filter : (a -> Bool) -> Array a -> Array a

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -50,6 +50,15 @@ export
 take : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray m a
 take _ (IA arr) = IA arr
 
+||| We can drop n elements from the start of an array. O(n)
+|||
+||| Note: If you only need a small portion of a potentially large
+|||       array the resto of which you no longer need, consider to
+|||       release the large array from memory by invoking `force`.
+export
+drop : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray m a
+drop _ (IA arr) = IA arr
+
 --------------------------------------------------------------------------------
 --          Mutable Arrays
 --------------------------------------------------------------------------------

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -2,6 +2,7 @@
 ||| mutable (linear) arrays.
 module Data.Array.Core
 
+import Data.Array.Index
 import Data.Linear
 import Data.Linear.Token
 import Data.Fin
@@ -49,15 +50,6 @@ at (IA ad) m =
 export
 take : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray m a
 take _ (IA arr) = IA arr
-
-||| We can drop n elements from the start of an array. O(n)
-|||
-||| Note: If you only need a small portion of a potentially large
-|||       array the rest of which you no longer need, consider to
-|||       release the large array from memory by invoking `force`.
-export
-drop : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray (minus n m) a
-drop _ (IA arr) = IA arr
 
 --------------------------------------------------------------------------------
 --          Mutable Arrays

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -44,7 +44,7 @@ at (IA ad) m =
 ||| a new size index.
 |||
 ||| Note: If you only need a small portion of a potentially large
-|||       array the resto of which you no longer need, consider to
+|||       array the rest of which you no longer need, consider to
 |||       release the large array from memory by invoking `force`.
 export
 take : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray m a
@@ -53,7 +53,7 @@ take _ (IA arr) = IA arr
 ||| We can drop n elements from the start of an array. O(n)
 |||
 ||| Note: If you only need a small portion of a potentially large
-|||       array the resto of which you no longer need, consider to
+|||       array the rest of which you no longer need, consider to
 |||       release the large array from memory by invoking `force`.
 export
 drop : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray m a
@@ -91,7 +91,7 @@ newMArray : (n : Nat) -> a -> (1 t : T1 rs) -> A1 rs (MArray n a)
 newMArray n v t =
   let m # t := ffi (prim__newArray (cast n) v) t in A (MA m) (unsafeBind t)
 
-||| Fills a new mutable array in `T1 [Wrold]`
+||| Fills a new mutable array in `T1 [World]`
 export %inline
 arrayIO : (n : Nat) -> a -> F1 [World] (IOArray n a)
 arrayIO n v t = let m # t := ffi (prim__newArray (cast n) v) t in MA m # t

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -56,7 +56,7 @@ take _ (IA arr) = IA arr
 |||       array the rest of which you no longer need, consider to
 |||       release the large array from memory by invoking `force`.
 export
-drop : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray m a
+drop : (0 m : Nat) -> IArray n a -> {auto 0 lte : LTE m n} -> IArray (minus n m) a
 drop _ (IA arr) = IA arr
 
 --------------------------------------------------------------------------------

--- a/src/Data/Array/Index.idr
+++ b/src/Data/Array/Index.idr
@@ -252,6 +252,20 @@ export
 minusFinLT (S k) FZ = LTESucc (minusLTE k 0)
 minusFinLT (S k) (FS x) = LTESucc (minusLTE k _)
 
+export
+0 minusLT : (x,m,n : Nat) -> LT x (n `minus` m) -> LT (x+m) n
+minusLT x _     0     y = absurd y
+minusLT x 0     (S k) y = rewrite plusZeroRightNeutral x in y
+minusLT x (S k) (S j) y =
+  let p1 := minusLT x k j y
+   in LTESucc (rewrite sym (plusSuccRightSucc x k) in p1)
+
+export
+inc : {m : _} -> Fin (n `minus` m) -> Fin n
+inc x =
+  let 0 p1 := finToNatLT x
+   in natToFinLT (finToNat x + m) @{minusLT _ _ _ p1}
+
 --------------------------------------------------------------------------------
 --          Relations
 --------------------------------------------------------------------------------

--- a/src/Data/Array/Indexed.idr
+++ b/src/Data/Array/Indexed.idr
@@ -301,10 +301,6 @@ curLTE s lte = transitive lte $ ixLTE s
 curLT s lte = let LTESucc p := ixLT s in LTESucc $ transitive lte p
 
 ||| We can drop n elements from an array. O(n)
-|||
-||| Note: If you only need a small portion of a potentially large
-|||       array the rest of which you no longer need, consider to
-|||       release the large array from memory by invoking `force`.
 export
 drop : {n : _} -> (m : Nat) -> IArray n a -> IArray (n `minus` m) a
 drop m arr = generate (n `minus` m) (\f => at arr (inc f))

--- a/src/Data/Array/Indexed.idr
+++ b/src/Data/Array/Indexed.idr
@@ -300,6 +300,15 @@ curLTE s lte = transitive lte $ ixLTE s
 0 curLT : (s : Ix (S m) n) -> LTE c (ixToNat s) -> LT c n
 curLT s lte = let LTESucc p := ixLT s in LTESucc $ transitive lte p
 
+||| We can drop n elements from an array. O(n)
+|||
+||| Note: If you only need a small portion of a potentially large
+|||       array the rest of which you no longer need, consider to
+|||       release the large array from memory by invoking `force`.
+export
+drop : {n : _} -> (m : Nat) -> IArray n a -> IArray (n `minus` m) a
+drop m arr = generate (n `minus` m) (\f => at arr (inc f))
+
 ||| Filter the values in a graph together with their corresponding
 ||| indices according to the given predicate.
 export


### PR DESCRIPTION
This PR adds `drop n xs`, which returns the suffix of `xs` after the first `n` elements, or the empty array (`A 0 empty`) if `n >= size`.

This implementation utilizes `take` since there is no backend support (`chez`, `js`) to permanently move an array's position to a new index.

Thanks to @dunhamsteve for helping with getting drop to compile.

Thanks to @stefan-hoeck for helping with proofs and implementation.

This PR closes https://github.com/stefan-hoeck/idris2-array/issues/45.

**Test**:

```
module Main

import Data.Array
import Data.Array.Indexed

%default total

partial
main : IO ()
main = do
  let test   = A 10 $ array (fromList [0,1,2,3,4,5,6,7,8,9])
  let drop'  = drop 3 test
  let drop'' = drop 10 test
  putStrLn $ show test.arr
  putStrLn $ show drop'.arr
  putStrLn $ show drop''.arr
```

**Output**:

```
array [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
array [3, 4, 5, 6, 7, 8, 9]
array []
```