### PR TITLE
[ performance ] use Integer for all FFI calls

### DIFF
--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -38,7 +38,8 @@ prim__arrayGet : AnyPtr -> Integer -> AnyPtr
 -- This is an optimized version of `prim_arrayGet` that allows us to read
 -- at an offset. On Chez, we can use the faster fixnum addition here,
 -- which can lead to a performance boost.
-%foreign "scheme:(lambda (b a o) (vector-ref b (fx+ a o)))"
+%foreign "scheme:(lambda (b a o) (vector-ref b (+ a o)))"
+         "chez:(lambda (b a o) (vector-ref b (fx+ a o)))"
          "javascript:lambda:(buf,at,offset)=>buf[Number(offset) + Number(at)]"
 prim__arrayGetOffset : AnyPtr -> (at, offset : Integer) -> AnyPtr
 
@@ -50,21 +51,23 @@ prim__arraySet : AnyPtr -> Integer -> (val : AnyPtr) -> PrimIO ()
          "javascript:lambda:(a,x,bi,v,w) => {const i = Number(bi); if (x[i] === v) {x[i] = w; return 1;} else {return 0;}}"
 prim__casSet : AnyPtr -> Integer -> (prev,val : a) -> Bits8
 
-
 export
-%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
+%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
+         "chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__copyArray : (src : AnyPtr) -> (srcOffset, len : Integer) ->
                   (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
-%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (bytevector-u8-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
+%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (bytevector-u8-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
+         "chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (bytevector-u8-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__bufToArr : (src : Buffer) -> (srcOffset, len : Integer) ->
                  (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (bytevector-u8-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
+         "chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (bytevector-u8-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__arrToBuf : (src : AnyPtr) -> (srcOffset, len : Integer) ->
                  (dst : Buffer) -> (dstOffset : Integer) -> PrimIO ()

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -24,35 +24,43 @@ import Syntax.T1
 --------------------------------------------------------------------------------
 
 %foreign "scheme:(lambda (x) (make-vector x))"
-         "javascript:lambda:(n) => new Array(n)"
-prim__emptyArray : Bits32 -> PrimIO AnyPtr
+         "javascript:lambda:(n,w) => new Array(Number(n))"
+prim__emptyArray : Integer -> PrimIO AnyPtr
 
-%extern prim__newArray : forall a . Bits32 -> a -> PrimIO AnyPtr
-%extern prim__arrayGet : forall a . AnyPtr -> Bits32 -> PrimIO a
-%extern prim__arraySet : forall a . AnyPtr -> Bits32 -> a -> PrimIO ()
+%foreign "scheme:(lambda (x i) (make-vector x i))"
+         "javascript:lambda:(bi,x,w) => Array(Number(bi)).fill(x)"
+prim__newArray : Integer -> AnyPtr -> PrimIO AnyPtr
+
+%foreign "scheme:(lambda (x i) (vector-ref x i))"
+         "javascript:lambda:(x,bi) => x[Number(bi)]"
+prim__arrayGet : AnyPtr -> Integer -> AnyPtr
+
+%foreign "scheme:(lambda (x i w) (vector-set! x i w))"
+         "javascript:lambda:(x,bi,w) => {const i = Number(bi); x[i] = w}"
+prim__arraySet : AnyPtr -> Integer -> (val : AnyPtr) -> PrimIO ()
 
 %foreign "scheme:(lambda (a x i v w) (if (vector-cas! x i v w) 1 0))"
-         "javascript:lambda:(a,x,i,v,w) => {if (x[i] === v) {x[i] = w; return 1;} else {return 0;}}"
-prim__casSet : AnyPtr -> Bits32 -> (prev,val : a) -> Bits8
+         "javascript:lambda:(a,x,bi,v,w) => {const i = Number(bi); if (x[i] === v) {x[i] = w; return 1;} else {return 0;}}"
+prim__casSet : AnyPtr -> Integer -> (prev,val : a) -> Bits8
 
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
-         "javascript:lambda:(b1,o1,len,b2,o2,t)=> {for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
-prim__copyArray : (src : AnyPtr) -> (srcOffset, len : Bits32) ->
-                  (dst : AnyPtr) -> (dstOffset : Bits32) -> PrimIO ()
+         "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
+prim__copyArray : (src : AnyPtr) -> (srcOffset, len : Integer) ->
+                  (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (bytevector-u8-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
-         "javascript:lambda:(b1,o1,len,b2,o2,t)=> {for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
-prim__bufToArr : (src : Buffer) -> (srcOffset, len : Bits32) ->
-                 (dst : AnyPtr) -> (dstOffset : Bits32) -> PrimIO ()
+         "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
+prim__bufToArr : (src : Buffer) -> (srcOffset, len : Integer) ->
+                 (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (bytevector-u8-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
-         "javascript:lambda:(b1,o1,len,b2,o2,t)=> {for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
-prim__arrToBuf : (src : AnyPtr) -> (srcOffset, len : Bits32) ->
-                 (dst : Buffer) -> (dstOffset : Bits32) -> PrimIO ()
+         "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
+prim__arrToBuf : (src : AnyPtr) -> (srcOffset, len : Integer) ->
+                 (dst : Buffer) -> (dstOffset : Integer) -> PrimIO ()
 
 --------------------------------------------------------------------------------
 --          Immutable Arrays
@@ -67,9 +75,7 @@ record IArray (n : Nat) (a : Type) where
 ||| Safely access a value in an array at the given position.
 export %inline
 at : IArray n a -> Fin n -> a
-at (IA ad) m =
-  let MkIORes v _ := prim__arrayGet ad (cast $ finToNat m) %MkWorld
-   in v
+at (IA ad) m = believe_me $ prim__arrayGet ad (cast $ finToNat m)
 
 ||| We can wrap a prefix of an array in O(1) simply by giving it
 ||| a new size index.
@@ -103,7 +109,7 @@ IOArray = MArray World
 export %inline
 marray1 : (n : Nat) -> a -> F1 s (MArray s n a)
 marray1 n v t =
-  let m # t := ffi (prim__newArray (cast n) v) t in MA m # t
+  let p # t := ffi (prim__newArray (cast n) (believe_me v)) t in MA p # t
 
 ||| Fills a new mutable array in `IO`
 export %inline
@@ -113,7 +119,7 @@ marray n v = lift1 (marray1 n v)
 export %inline
 unsafeMArray1 : (n : Nat) -> F1 s (MArray s n a)
 unsafeMArray1 n t =
-  let m # t := ffi (prim__emptyArray (cast n)) t in MA m # t
+  let p # t := ffi (prim__emptyArray (cast n)) t in MA p # t
 
 ||| Allocates a new, empty, mutable array in `IO`
 export %inline
@@ -123,7 +129,7 @@ unsafeMArray n = lift1 (unsafeMArray1 n)
 ||| Safely write a value to a mutable array.
 export %inline
 set : (r : MArray s n a) -> Fin n -> a -> F1' s
-set (MA arr) ix v = ffi (prim__arraySet arr (cast $ finToNat ix) v)
+set (MA arr) ix v = ffi (prim__arraySet arr (cast $ finToNat ix) (believe_me v))
 
 ||| Safely read a value from a mutable array.
 |||
@@ -132,7 +138,7 @@ set (MA arr) ix v = ffi (prim__arraySet arr (cast $ finToNat ix) v)
 ||| linear context.
 export %inline
 get : (r : MArray s n a) -> Fin n -> F1 s a
-get (MA arr) ix = ffi (prim__arrayGet arr (cast $ finToNat ix))
+get (MA arr) ix t = believe_me (prim__arrayGet arr (cast $ finToNat ix)) # t
 
 ||| Safely modify a value in a mutable array.
 export %inline

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -39,7 +39,7 @@ prim__arrayGet : AnyPtr -> Integer -> AnyPtr
 -- at an offset. On Chez, we can use the faster fixnum addition here,
 -- which can lead to a performance boost.
 %foreign "scheme:(lambda (b a o) (vector-ref b (+ a o)))"
-         "chez:(lambda (b a o) (vector-ref b (fx+ a o)))"
+         "scheme,chez:(lambda (b a o) (vector-ref b (fx+ a o)))"
          "javascript:lambda:(buf,at,offset)=>buf[Number(offset) + Number(at)]"
 prim__arrayGetOffset : AnyPtr -> (at, offset : Integer) -> AnyPtr
 
@@ -53,21 +53,21 @@ prim__casSet : AnyPtr -> Integer -> (prev,val : a) -> Bits8
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
-         "chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
+         "scheme,chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__copyArray : (src : AnyPtr) -> (srcOffset, len : Integer) ->
                   (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (bytevector-u8-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
-         "chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (bytevector-u8-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
+         "scheme,chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (bytevector-u8-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__bufToArr : (src : Buffer) -> (srcOffset, len : Integer) ->
                  (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
 %foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (bytevector-u8-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
-         "chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (bytevector-u8-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
+         "scheme,chez: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (bytevector-u8-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__arrToBuf : (src : AnyPtr) -> (srcOffset, len : Integer) ->
                  (dst : Buffer) -> (dstOffset : Integer) -> PrimIO ()

--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -35,6 +35,13 @@ prim__newArray : Integer -> AnyPtr -> PrimIO AnyPtr
          "javascript:lambda:(x,bi) => x[Number(bi)]"
 prim__arrayGet : AnyPtr -> Integer -> AnyPtr
 
+-- This is an optimized version of `prim_arrayGet` that allows us to read
+-- at an offset. On Chez, we can use the faster fixnum addition here,
+-- which can lead to a performance boost.
+%foreign "scheme:(lambda (b a o) (vector-ref b (fx+ a o)))"
+         "javascript:lambda:(buf,at,offset)=>buf[Number(offset) + Number(at)]"
+prim__arrayGetOffset : AnyPtr -> (at, offset : Integer) -> AnyPtr
+
 %foreign "scheme:(lambda (x i w) (vector-set! x i w))"
          "javascript:lambda:(x,bi,w) => {const i = Number(bi); x[i] = w}"
 prim__arraySet : AnyPtr -> Integer -> (val : AnyPtr) -> PrimIO ()
@@ -45,13 +52,13 @@ prim__casSet : AnyPtr -> Integer -> (prev,val : a) -> Bits8
 
 
 export
-%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (vector-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
+%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (vector-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__copyArray : (src : AnyPtr) -> (srcOffset, len : Integer) ->
                   (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
 
 export
-%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (+ o2 i) (bytevector-u8-ref b1 (+ o1 i))) (go (+ 1 i))))))) (go 0)))"
+%foreign "scheme: (lambda (b1 o1 len b2 o2) (letrec ((go (lambda (i) (when (< i len) (begin (vector-set! b2 (fx+ o2 i) (bytevector-u8-ref b1 (fx+ o1 i))) (go (fx+ 1 i))))))) (go 0)))"
          "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
 prim__bufToArr : (src : Buffer) -> (srcOffset, len : Integer) ->
                  (dst : AnyPtr) -> (dstOffset : Integer) -> PrimIO ()
@@ -76,6 +83,13 @@ record IArray (n : Nat) (a : Type) where
 export %inline
 at : IArray n a -> Fin n -> a
 at (IA ad) m = believe_me $ prim__arrayGet ad (cast $ finToNat m)
+
+||| Safely access a value in an array at the given position
+||| and offset.
+export %inline
+atOffset : IArray n a -> Fin m -> (off : Nat) -> (0 p : LTE (off+m) n) => a
+atOffset (IA ad) m off =
+  believe_me $ prim__arrayGetOffset ad (cast $ finToNat m) (cast off)
 
 ||| We can wrap a prefix of an array in O(1) simply by giving it
 ||| a new size index.

--- a/src/Data/Buffer/Core.idr
+++ b/src/Data/Buffer/Core.idr
@@ -23,7 +23,7 @@ prim__getByte : Buffer -> (offset : Integer) -> Bits8
 ||| which can lead to a performance boost.
 export
 %foreign "scheme:(lambda (b a o) (bytevector-u8-ref b (+ a o)))"
-         "chez:(lambda (b a o) (bytevector-u8-ref b (fx+ a o)))"
+         "scheme,chez:(lambda (b a o) (bytevector-u8-ref b (fx+ a o)))"
          "javascript:lambda:(buf,at,offset)=>buf[Number(offset) + Number(at)]"
 prim__getByteOffset : Buffer -> (at, offset : Integer) -> Bits8
 

--- a/src/Data/Buffer/Core.idr
+++ b/src/Data/Buffer/Core.idr
@@ -22,7 +22,8 @@ prim__getByte : Buffer -> (offset : Integer) -> Bits8
 ||| at an offset. On Chez, we can use the faster fixnum addition here,
 ||| which can lead to a performance boost.
 export
-%foreign "scheme:(lambda (b a o) (bytevector-u8-ref b (fx+ a o)))"
+%foreign "scheme:(lambda (b a o) (bytevector-u8-ref b (+ a o)))"
+         "chez:(lambda (b a o) (bytevector-u8-ref b (fx+ a o)))"
          "javascript:lambda:(buf,at,offset)=>buf[Number(offset) + Number(at)]"
 prim__getByteOffset : Buffer -> (at, offset : Integer) -> Bits8
 

--- a/src/Data/Buffer/Core.idr
+++ b/src/Data/Buffer/Core.idr
@@ -15,23 +15,23 @@ import System.File
 
 export
 %foreign "scheme:(lambda (b o) (bytevector-u8-ref b o))"
-         "javascript:lambda:(buf,offset)=>buf[offset]"
-prim__getByte : Buffer -> (offset : Bits32) -> Bits8
+         "javascript:lambda:(buf,offset)=>buf[Number(offset)]"
+prim__getByte : Buffer -> (offset : Integer) -> Bits8
 
 export
 %foreign "scheme:(lambda (b o v) (bytevector-u8-set! b o v))"
-         "javascript:lambda:(buf,offset,value,t)=>{buf[offset] = value; return t}"
-prim__setByte : Buffer -> (offset : Bits32) -> (val : Bits8) -> PrimIO ()
+         "javascript:lambda:(buf,offset,value,t)=>{buf[Number(offset)] = value; return t}"
+prim__setByte : Buffer -> (offset : Integer) -> (val : Bits8) -> PrimIO ()
 
 export
 %foreign "scheme:(lambda (n) (make-bytevector n 0))"
-         "javascript:lambda:(s,w)=>new Uint8Array(s)"
-prim__newBuf : Bits32 -> PrimIO Buffer
+         "javascript:lambda:(s,w)=>new Uint8Array(Number(s))"
+prim__newBuf : Integer -> PrimIO Buffer
 
 export
 %foreign "scheme:blodwen-buffer-getstring"
-         "javascript:lambda:(buf,offset,len)=> new TextDecoder().decode(buf.subarray(offset, offset+len))"
-prim__getString : Buffer -> (offset,len : Bits32) -> String
+         "javascript:lambda:(buf,offset,len)=> new TextDecoder().decode(buf.subarray(Number(offset), Number(offset+len)))"
+prim__getString : Buffer -> (offset,len : Integer) -> String
 
 export
 %foreign "scheme:(lambda (v) (string->utf8 v))"
@@ -40,9 +40,9 @@ prim__fromString : (val : String) -> Buffer
 
 export
 %foreign "scheme:(lambda (b1 o1 len b2 o2) (bytevector-copy! b1 o1 b2 o2 len))"
-         "javascript:lambda:(b1,o1,len,b2,o2,t)=> {for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
-prim__copy : (src : Buffer) -> (srcOffset, len : Bits32) ->
-             (dst : Buffer) -> (dstOffset : Bits32) -> PrimIO ()
+         "javascript:lambda:(b1,bo1,blen,b2,bo2,t)=> {const o1 = Number(bo1); const len = Number(blen); const o2 = Number(bo2); for (let i = 0; i < len; i++) {b2[o2+i] = b1[o1+i];}; return t}"
+prim__copy : (src : Buffer) -> (srcOffset, len : Integer) ->
+             (dst : Buffer) -> (dstOffset : Integer) -> PrimIO ()
 
 --------------------------------------------------------------------------------
 --          Immutable Buffers


### PR DESCRIPTION
Together with using the Chez specific `fx+` when accessing arrays and byte vectors with an offset, this gives an up to 40% performance boost when profiling idris2-bytestring.