### PR TITLE
[ new ] casswap

### DIFF
--- a/src/Data/Array/Core.idr
+++ b/src/Data/Array/Core.idr
@@ -203,6 +203,21 @@ casset (MA arr) x pre val t =
     0 => False # t
     _ => True # t
 
+||| Atomically overwrites at the given position of the mutable array.
+|||
+||| This is supported and has been tested on the Chez and Racket backends.
+||| It trivially works on the JavaScript backends, which are single-threaded
+||| anyway.
+export %inline
+casswap : (r : MArray s n a) -> Fin n -> a -> F1' s
+casswap r x v t = assert_total (loop t)
+  where
+    covering loop : F1' s
+    loop t =
+      let cur # t  := get r x t
+          True # t := casset r x cur v t | _ # t => loop t
+       in () # t
+
 ||| Atomic modification of an array position using a CAS-loop internally.
 |||
 ||| This is supported and has been tested on the Chez and Racket backends.

--- a/test/src/Array.idr
+++ b/test/src/Array.idr
@@ -292,6 +292,12 @@ prop_casset_diff =
     [x,y] <- forAll $ hlist [anyBits8, anyBits8]
     (False,x) === alloc 3 x (\r => casWriteGet r (x+1) y)
 
+prop_casswap : Property
+prop_casswap =
+  property $ do
+    [x,y] <- forAll $ hlist [anyBits8, anyBits8]
+    y === alloc 3 x (\r,t => let _ # t := casswap r 2 y t in get r 2 t)
+
 prop_casupdate : Property
 prop_casupdate =
   property $ do
@@ -349,6 +355,7 @@ props = MkGroup "Array"
   , ("prop_monoid_right_neutral", prop_monoid_right_neutral)
   , ("prop_casset", prop_casset)
   , ("prop_casset_diff", prop_casset_diff)
+  , ("prop_casswap", prop_casswap)
   , ("prop_casupdate", prop_casupdate)
   , ("prop_casmodify", prop_casmodify)
   ]


### PR DESCRIPTION
This PR adds the `casswap` function to `Data.Array.Core`.